### PR TITLE
Revive speed fixes, death movement configs, and config loading [2.1.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See the `config.yml` file of the plugin, more details in the [Wiki](https://gith
 
 ## Dependencies
 
-There are no active dependenties at this time.
+Despite the name, this plugin does not support setting `hardcore=true` in server.properties. If you'd like to have this as a feature, please let us know!
 
 ## Issue? Need help or have suggestions?
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hardcorelife</groupId>
     <artifactId>hardcorelife</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>Hardcorelife</name>

--- a/src/main/java/hardcorelife/chryscorelab/Touchy.java
+++ b/src/main/java/hardcorelife/chryscorelab/Touchy.java
@@ -47,7 +47,7 @@ public final class Touchy extends JavaPlugin {
         getConfig().options().copyDefaults(true);
 
         // Initialize config files
-        livesConfig = GetLivesConfig();
+        livesConfig = getLivesConfig();
         config = getConfig();
 
         Objects.requireNonNull(getCommand("lives")).setExecutor(new Lives());
@@ -87,7 +87,7 @@ public final class Touchy extends JavaPlugin {
         }
 
         // Delete existing lives.yml
-        GetLivesConfigFile().delete();
+        getLivesConfigFile().delete();
         // Clear playerlife cache
         PlayerLife.clearLivesData();
 
@@ -113,8 +113,8 @@ public final class Touchy extends JavaPlugin {
         }
     }
 
-    private FileConfiguration GetLivesConfig() {
-        File LivesConfigFile = GetLivesConfigFile();
+    private FileConfiguration getLivesConfig() {
+        File LivesConfigFile = getLivesConfigFile();
         FileConfiguration LivesConfig = new YamlConfiguration();
         try {
             LivesConfig.load(LivesConfigFile);
@@ -124,8 +124,8 @@ public final class Touchy extends JavaPlugin {
         return LivesConfig;
     }
 
-    private void SetLivesConfig(FileConfiguration LivesConfig) {
-        File LivesConfigFile = GetLivesConfigFile();
+    private void setLivesConfig(FileConfiguration LivesConfig) {
+        File LivesConfigFile = getLivesConfigFile();
         try {
             LivesConfig.save(LivesConfigFile);
         } catch (IOException e) {
@@ -133,7 +133,7 @@ public final class Touchy extends JavaPlugin {
         }
     }
 
-    private File GetLivesConfigFile() {
+    private File getLivesConfigFile() {
         // Ensures lives.yml exists, and returns the file object
         File LivesConfigFile = new File(getDataFolder(), "lives.yml");
         if (!LivesConfigFile.exists()) {
@@ -153,6 +153,15 @@ public final class Touchy extends JavaPlugin {
         return config.getBoolean("global_lives");
     }
 
+    public boolean deathMovementEnabled() {
+        // Returns the death_movement value from config.yml
+        if (config.isSet("death_movement")) {
+            return config.getBoolean("death_movement");
+        } else {
+            return globalLivesEnabled();
+        }
+    }
+
     public int getPlayerLivesConfig(UUID uuid) {
         // Gets the number of lives a player has from config.yml
         // If no data is set, the default is returned
@@ -162,7 +171,7 @@ public final class Touchy extends JavaPlugin {
     public void savePlayerLifeConfig(UUID uuid, int lives) {
         // Update the life value for a single player, in lives.yml
         livesConfig.set(uuid + ".lives", lives);
-        SetLivesConfig(livesConfig);
+        setLivesConfig(livesConfig);
     }
 
     public void saveHashmapData(HashMap<UUID, Integer> lives) {
@@ -170,7 +179,7 @@ public final class Touchy extends JavaPlugin {
         for (Map.Entry<UUID, Integer> entry : lives.entrySet()) {
             livesConfig.set(entry.getKey() + ".lives", entry.getValue());
         }
-        SetLivesConfig(livesConfig);
+        setLivesConfig(livesConfig);
     }
 
     public boolean naturalRegEnabled() {

--- a/src/main/java/hardcorelife/chryscorelab/Touchy.java
+++ b/src/main/java/hardcorelife/chryscorelab/Touchy.java
@@ -34,6 +34,8 @@ public final class Touchy extends JavaPlugin {
     private static Touchy instance;
     private static boolean reset_on_unload = false;
     private static Server server;
+    private static FileConfiguration config;
+    private static FileConfiguration livesConfig;
 
     @Override
     public void onEnable() {
@@ -43,7 +45,10 @@ public final class Touchy extends JavaPlugin {
         // Plugin startup logic
         saveDefaultConfig();
         getConfig().options().copyDefaults(true);
-        GetLivesConfigFile();
+
+        // Initialize config files
+        livesConfig = GetLivesConfig();
+        config = getConfig();
 
         Objects.requireNonNull(getCommand("lives")).setExecutor(new Lives());
         Objects.requireNonNull(getCommand("setlives")).setExecutor(new SetLives());
@@ -140,37 +145,32 @@ public final class Touchy extends JavaPlugin {
 
     public int getDefaultLives() {
         // Returns the starting_lives value from config.yml
-        FileConfiguration defaultLivesConfig = getConfig();
-        return defaultLivesConfig.getInt("starting_lives");
+        return config.getInt("starting_lives");
     }
 
     public boolean globalLivesEnabled() {
         // Returns the global_lives value from config.yml
-        FileConfiguration defaultLivesConfig = getConfig();
-        return defaultLivesConfig.getBoolean("global_lives");
+        return config.getBoolean("global_lives");
     }
 
     public int getPlayerLivesConfig(UUID uuid) {
         // Gets the number of lives a player has from config.yml
         // If no data is set, the default is returned
-        FileConfiguration livesConfig = GetLivesConfig();
         return livesConfig.getInt(uuid + ".lives", getDefaultLives());
     }
 
     public void savePlayerLifeConfig(UUID uuid, int lives) {
         // Update the life value for a single player, in lives.yml
-        FileConfiguration LivesConfig = GetLivesConfig();
-        LivesConfig.set(uuid + ".lives", lives);
-        SetLivesConfig(LivesConfig);
+        livesConfig.set(uuid + ".lives", lives);
+        SetLivesConfig(livesConfig);
     }
 
     public void saveHashmapData(HashMap<UUID, Integer> lives) {
         // Invoked during plugin shutdown, saves in-memory config to disk
-        FileConfiguration LivesConfig = GetLivesConfig();
         for (Map.Entry<UUID, Integer> entry : lives.entrySet()) {
-            LivesConfig.set(entry.getKey() + ".lives", entry.getValue());
+            livesConfig.set(entry.getKey() + ".lives", entry.getValue());
         }
-        SetLivesConfig(LivesConfig);
+        SetLivesConfig(livesConfig);
     }
 
     public boolean naturalRegEnabled() {

--- a/src/main/java/hardcorelife/chryscorelab/commands/SetLives.java
+++ b/src/main/java/hardcorelife/chryscorelab/commands/SetLives.java
@@ -33,8 +33,6 @@ public class SetLives implements CommandExecutor {
         // Usage: /setlives [player] <value>
         // Must be a number greater than 0
 
-        // TODO - Handle when a player's life count hits 0, then is increased
-
         if (args.length == 2) {
             // Set another player's life count
             player = server.getPlayer(args[0]);
@@ -78,7 +76,7 @@ public class SetLives implements CommandExecutor {
 
                 // Revive all players
                 for (Player p : server.getOnlinePlayers()) {
-                    revivePlayer(p);
+                    PlayerLife.revivePlayer(p);
                 }
 
                 // Restrict resetserver permission
@@ -91,24 +89,11 @@ public class SetLives implements CommandExecutor {
                 server.broadcast(reset_comp);
             } else {
                 // Revive the player without altering life count
-                revivePlayer(player);
+                PlayerLife.revivePlayer(player);
             }
         }
 
         return true;
-    }
-
-    public void revivePlayer(Player player) {
-        // Force-respawn a player without altering their life count
-        // Mainly used when reviving a player who experiences permadeath
-        player.setGameMode(GameMode.SURVIVAL);
-
-        PlayerLife.addLife(player);
-        player.setHealth(0);
-
-        // Re-enable movement
-        player.setWalkSpeed(0.2f);
-        player.setFlySpeed(0.1f);
     }
 
 }

--- a/src/main/java/hardcorelife/chryscorelab/commands/SetLives.java
+++ b/src/main/java/hardcorelife/chryscorelab/commands/SetLives.java
@@ -76,9 +76,9 @@ public class SetLives implements CommandExecutor {
                 // Handle server life refresh
                 server.setDefaultGameMode(GameMode.SURVIVAL);
 
-                // Reset everyone's gamemode
+                // Revive all players
                 for (Player p : server.getOnlinePlayers()) {
-                    p.setGameMode(GameMode.SURVIVAL);
+                    revivePlayer(p);
                 }
 
                 // Restrict resetserver permission
@@ -90,15 +90,25 @@ public class SetLives implements CommandExecutor {
                         .text("The server's life count has been increased to: " + String.valueOf(newCount));
                 server.broadcast(reset_comp);
             } else {
-                // Handle player life refresh
-                player.setGameMode(GameMode.SURVIVAL);
-                player.setWalkSpeed(0.2f);
-                player.setFlySpeed(0.1f);
-                // It might be worth tp-ing the player to the world[0] spawn
+                // Revive the player without altering life count
+                revivePlayer(player);
             }
         }
 
         return true;
+    }
+
+    public void revivePlayer(Player player) {
+        // Force-respawn a player without altering their life count
+        // Mainly used when reviving a player who experiences permadeath
+        player.setGameMode(GameMode.SURVIVAL);
+
+        PlayerLife.addLife(player);
+        player.setHealth(0);
+
+        // Re-enable movement
+        player.setWalkSpeed(0.2f);
+        player.setFlySpeed(0.1f);
     }
 
 }

--- a/src/main/java/hardcorelife/chryscorelab/helpers/PlayerLife.java
+++ b/src/main/java/hardcorelife/chryscorelab/helpers/PlayerLife.java
@@ -1,5 +1,6 @@
 package hardcorelife.chryscorelab.helpers;
 
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 
 import hardcorelife.chryscorelab.Touchy;
@@ -15,6 +16,19 @@ public class PlayerLife {
     public static void initPlayer(Player player) {
         // Triggers the player data to be loaded from config.yml
         getLives(player);
+    }
+
+    public static void revivePlayer(Player player) {
+        // Force-respawn a player without altering their life count
+        // Mainly used when reviving a player who experiences permadeath
+        player.setGameMode(GameMode.SURVIVAL);
+
+        addLife(player);
+        player.setHealth(0);
+
+        // Re-enable movement
+        player.setWalkSpeed(0.2f);
+        player.setFlySpeed(0.1f);
     }
 
     public static int getLives(Player player) {

--- a/src/main/java/hardcorelife/chryscorelab/listeners/PlayerDeath.java
+++ b/src/main/java/hardcorelife/chryscorelab/listeners/PlayerDeath.java
@@ -81,8 +81,8 @@ public class PlayerDeath implements Listener {
     }
 
     private static void respawnPlayer(Player player) {
-        // Handle respawning a new player
-        // This may be necessary if hardcore == True
+        // Handle respawning a new player, in a non-permadeath fashion
+        // TODO: This does not work when hardcore = true
         player.setGameMode(server.getDefaultGameMode());
     }
 

--- a/src/main/java/hardcorelife/chryscorelab/listeners/PlayerDeath.java
+++ b/src/main/java/hardcorelife/chryscorelab/listeners/PlayerDeath.java
@@ -65,14 +65,18 @@ public class PlayerDeath implements Listener {
                 TextComponent component = Component.text(player.getName() + " has run out of lives.");
                 server.broadcast(component);
                 player.setGameMode(GameMode.SPECTATOR);
-                // Prevent movement on death
-                player.setFlySpeed(0);
-                player.setWalkSpeed(0);
+                // Revive the player. Allows teleport to work
+                player.setHealth(20);
                 player.teleport(deathLocation);
 
             } else {
                 respawnPlayer(player);
             }
+        }
+        // Prevent movement on death
+        if (!touchy.deathMovementEnabled()) {
+            player.setFlySpeed(0);
+            player.setWalkSpeed(0);
         }
     }
 

--- a/src/main/java/hardcorelife/chryscorelab/listeners/PlayerJoinServer.java
+++ b/src/main/java/hardcorelife/chryscorelab/listeners/PlayerJoinServer.java
@@ -1,6 +1,7 @@
 package hardcorelife.chryscorelab.listeners;
 
 import hardcorelife.chryscorelab.Touchy;
+
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -30,7 +31,7 @@ public class PlayerJoinServer implements Listener {
         } else {
             // Handle when a player's life count was increased while they were away
             if (player.getGameMode() == GameMode.SPECTATOR) {
-                player.setGameMode(GameMode.SURVIVAL);
+                PlayerLife.revivePlayer(player);
             }
         }
 

--- a/src/main/java/hardcorelife/chryscorelab/listeners/PlayerJoinServer.java
+++ b/src/main/java/hardcorelife/chryscorelab/listeners/PlayerJoinServer.java
@@ -27,10 +27,14 @@ public class PlayerJoinServer implements Listener {
 
         if (PlayerLife.getLives(player) == 0) {
             player.setGameMode(GameMode.SPECTATOR);
+        } else {
+            // Handle when a player's life count was increased while they were away
+            if (player.getGameMode() == GameMode.SPECTATOR) {
+                player.setGameMode(GameMode.SURVIVAL);
+            }
         }
 
-        // TODO - Show messages about the number of lives remaining server/player,
-        // sending to the players (even more, show a history of past events)
+        // TODO - Show a history of past death events
         if (touchy.globalLivesEnabled()) {
             player.sendMessage(" Welcome back aboard " + player.getName() + "! The server has "
                     + PlayerLife.getLives(player) + " live(s) remaining");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 starting_lives: 3
 global_lives: true # true : Players will share lives with the server | False : Players will have their own lives
-natural_regeneration: true # false : the gamerule is disabled. This should be false, if you want the hardcore mode.
+#death_movement: true # Allow movement after hitting permadeath. If unset, defaults to the value of global_lives
+natural_regeneration: true # false : the gamerule is disabled. This should be false, if you want the hardcore mode
 language: en_EN # English by Default


### PR DESCRIPTION
Fixes #10, releases 2.1.0

Overhauls the process for handling movement after permadeath, without changing behavior from 2.0.0. Also adds support for reviving a player/server who's life count has hit 0, via the `/setlives` command.

- Adds the ability to enable/disable movement prevention after permadeath
  - Added `death_movement` to config.yml
    - If unspecified, defaults to the value of `global_lives` 
  - Updated permadeath handler to only restrict movement if `death_movement: True`
- Adds support for reviving a player/server who's life has hit 0, via `/setlives`
  - Increasing life count from 0 will change the player's gamemode back to survival, add an extra life to the player, then immediately kill the player. This allows us to piggyback on the server's normal respawning system, and give the revived player the ability to respawn on their own terms.
- Updated handing of configuration files to only read values on server start. 
  - This allows server operators to modify plugin files without affecting the running server.
  - Changes from config.yaml will be reloaded, while changes to lives.yml will be overwritten on server reload/shutdown.
- Documented that `hardcore = true` does not work properly