### PR TITLE
Add actions ci

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -21,7 +21,9 @@ jobs:
         run: mvn --batch-mode --update-snapshots verify
 
       - name: Prepare .jar file(s) for artifacting
-        run: mkdir staging && cp target/*.jar staging
+        run:
+          - mkdir staging && cp target/*.jar staging
+          - rm staging/original-*.jar
 
       - name: Upload build artifact(s)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -1,6 +1,11 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    # Build changes to all branches
+    branches: ["*"]
+    # Build semver tags
+    tags: ["*.*.*"]
 
 jobs:
   build:

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -25,9 +25,9 @@ jobs:
           mkdir staging && cp target/*.jar staging
           rm staging/original-*.jar
 
-      - name: Set the build's version name
+      - name: Set the build version name
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
       - name: Upload build artifact(s)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -21,9 +21,9 @@ jobs:
         run: mvn --batch-mode --update-snapshots verify
 
       - name: Prepare .jar file(s) for artifacting
-        run:
-          - mkdir staging && cp target/*.jar staging
-          - rm staging/original-*.jar
+        run: |
+          mkdir staging && cp target/*.jar staging
+          rm staging/original-*.jar
 
       - name: Upload build artifact(s)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -25,8 +25,12 @@ jobs:
           mkdir staging && cp target/*.jar staging
           rm staging/original-*.jar
 
+      - name: Set the build's version name
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
       - name: Upload build artifact(s)
         uses: actions/upload-artifact@v2
         with:
-          name: Package
+          name: hardcorelife-${{ steps.get_version.outputs.VERSION }}
           path: staging

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: "16"
           distribution: "adopt"
-          cache: maven
+          cache: maven # Dramatically decreases build times
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -1,0 +1,30 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: "16"
+          distribution: "adopt"
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+
+      - name: Prepare .jar file(s) for artifacting
+        run: mkdir staging && cp target/*.jar staging
+
+      - name: Upload build artifact(s)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Package
+          path: staging


### PR DESCRIPTION
Adds a GitHub Action to execute `mvn verify` every time there is a push to this repository. Based on the [billing information](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) provided by GitHub, and my own testing, this existing workflow can be executed 4,000 times each month before we hit any limits.

I also made it so all builds will upload the compiled jar files to the build logs ([example](https://github.com/Chryscorelab/HardcoreLife/actions/runs/1251507610)), assuming the build was successful. The zip file will be named after the associated branch or tag, meaning it will make uploading new releases easier, since the build process will be extremely predictable.

This also will validate that all pull requests are shipping buildable code, which is a major plus.

@DaFray31 for visibility